### PR TITLE
fix: 明日预约模式下座位列表无法显示已占用座位

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -248,7 +248,7 @@ export default function Dashboard() {
     }
   }, [opMode]);
 
-  // 场馆变更时加载座位列表
+  // 场馆变更或模式切换时加载座位列表
   useEffect(() => {
     async function fetchSeatsForRoom() {
       // 需要有效的 Cookie 和 libId
@@ -259,7 +259,9 @@ export default function Dashboard() {
 
       setLoadingSeats(true);
       try {
-        const data = await getRoomSeats(parseInt(libId), cookieStr.trim(), apiConfig);
+        // 明日预约模式(mode=1)返回全部座位，今日抢座(mode=2)仅返回空闲
+        const mode = opMode === 'scheduled' ? 1 : 2;
+        const data = await getRoomSeats(parseInt(libId), cookieStr.trim(), apiConfig, mode);
         // 只保留可用座位用于选择
         const availableSeats = data.seats.filter(s => s.available);
         setDynamicSeats(availableSeats);
@@ -267,7 +269,7 @@ export default function Dashboard() {
         if (selectedSeatKey && !availableSeats.find(s => s.key === selectedSeatKey)) {
           setSelectedSeatKey("");
         }
-        console.log(`✅ 加载场馆 ${libId} 的 ${availableSeats.length} 个可用座位`);
+        console.log(`✅ 加载场馆 ${libId} 的 ${availableSeats.length} 个可用座位 (模式: ${opMode})`);
       } catch (error) {
         console.warn("加载座位列表失败:", error);
         setDynamicSeats([]);
@@ -276,10 +278,10 @@ export default function Dashboard() {
       }
     }
 
-    // 场馆切换后 300ms 加载座位
+    // 场馆切换或模式切换后 300ms 加载座位
     const debounceTimer = setTimeout(fetchSeatsForRoom, 300);
     return () => clearTimeout(debounceTimer);
-  }, [libId, cookieStr, apiConfig]); // 添加 apiConfig 依赖
+  }, [libId, cookieStr, apiConfig, opMode]); // opMode 变化时也要刷新座位列表
 
   // 滚动日志
   useEffect(() => {
@@ -771,7 +773,7 @@ export default function Dashboard() {
                           <>
                             <option value="">选择座位...</option>
                             {dynamicSeats
-                              .sort((a, b) => a.name.localeCompare(b.name, 'zh-CN', { numeric: true }))
+                              .sort((a, b) => (a.name || '').localeCompare(b.name || '', 'zh-CN', { numeric: true }))
                               .map((seat) => (
                                 <option key={seat.key} value={seat.key}>
                                   {seat.name}

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -100,12 +100,17 @@ export class LibraryService {
   }
 
   // 2. Get Seat Layout
-  async getSeatLayout(libId: number): Promise<Seat[]> {
+  // 明日预约需要展示全部座位
+  async getSeatLayout(libId: number, includeOccupied = false): Promise<Seat[]> {
     const query = `query libLayout($libId: Int, $libType: Int) { userAuth { reserve { libs(libType: $libType, libId: $libId) { lib_layout { seats { key name status seat_status type } } } } } }`;
     const data = await this.sendGraphql("libLayout", query, { libId, libType: -1 });
     const seats = data?.data?.userAuth?.reserve?.libs?.[0]?.lib_layout?.seats || [];
 
     return seats.filter((s: any) => {
+      // 过滤掉 name 为空的无效元素
+      if (!s.name) return false;
+      // 明日预约模式下不过滤占用状态，返回全部座位
+      if (includeOccupied) return true;
       const seatStatus = s.seat_status !== undefined ? s.seat_status : 1;
       return seatStatus === 1;
     }).map((s: any) => ({
@@ -131,9 +136,10 @@ export class LibraryService {
   }
 
   // 4. Find Seat Key by Number
-  async findSeatKeyByNumber(libId: number, seatNumber: string): Promise<string | null> {
+  // includeOccupied 传给 getSeatLayout，确保明日预约时也能解析被占用座位的 Key
+  async findSeatKeyByNumber(libId: number, seatNumber: string, includeOccupied = false): Promise<string | null> {
     try {
-      const seats = await this.getSeatLayout(libId);
+      const seats = await this.getSeatLayout(libId, includeOccupied);
       const match = seats.find(s => s.name === seatNumber);
       return match ? match.key : null;
     } catch (e) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -54,7 +54,9 @@ export async function submitRequest(
         console.log(msg);
         if (onStatusUpdate) onStatusUpdate(msg, "info");
         try {
-          const resolvedKey = await service.findSeatKeyByNumber(request.libId, request.seatNumber);
+          // 明日预约模式(mode=1)需要包含今日被占用的座位，否则解析不到 Key
+          const includeOccupied = request.mode === 1;
+          const resolvedKey = await service.findSeatKeyByNumber(request.libId, request.seatNumber, includeOccupied);
 
           if (controller.signal.aborted) throw new Error("Task cancelled");
 
@@ -224,15 +226,18 @@ export async function getDynamicRooms(
 
 /**
  * 动态获取指定场馆的座位布局（需要有效 Cookie）
+ * @param mode 预约模式：1=明日预约（返回全部座位），2=今日抢座（仅返回空闲座位）
  */
 export async function getRoomSeats(
   roomId: number,
   cookie: string,
-  apiConfig?: { apiUrl?: string; origin?: string; referer?: string }
+  apiConfig?: { apiUrl?: string; origin?: string; referer?: string },
+  mode: number = 2
 ): Promise<SeatLayoutResponse> {
   const apiUrl = apiConfig?.apiUrl || DEFAULT_API_CONFIG.apiUrl;
   const service = new LibraryService(cookie, apiUrl, apiConfig?.origin, apiConfig?.referer);
-  const rawSeats = await service.getSeatLayout(roomId);
+  const includeOccupied = mode === 1;
+  const rawSeats = await service.getSeatLayout(roomId, includeOccupied);
 
   const seats: DynamicSeat[] = rawSeats.map(s => ({
     key: s.key,


### PR DESCRIPTION
- getSeatLayout 增加 includeOccupied 参数，明日预约模式下跳过 seat_status 过滤
- findSeatKeyByNumber 透传 includeOccupied，解决手动输入座位号时解析不到 Key 的问题
- getRoomSeats 增加 mode 参数，根据预约模式控制是否返回全部座位
- Dashboard 座位加载 useEffect 加入 opMode 依赖，切换模式时自动刷新座位列表
- 过滤掉 name 为空的布局占位符元素，排序增加空值保护